### PR TITLE
add match by filename in tags when calc score

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -83,6 +83,39 @@ LibSearch.prototype.optimizeQueryTerms = function(input) {
 
 LibSearch.prototype.optimizeSubs = function(response, input) {
     // based on OpenSRTJS, under MIT - Copyright (c) 2014 Eóin Martin
+    var fileTags;
+    var matchTags = function (sub, maxScore) {
+        if(!input.filename) return 0;
+
+        if (!fileTags) {
+            fileTags = input.filename.toLowerCase()
+                                     .split(/[^a-z0-9]+/gi)
+                                     .filter((tag) => { return tag.length > 1 }); 
+        }
+
+        if (fileTags.length === 0) return 0;
+        
+        var subNames = (sub.MovieReleaseName + ' ' + sub.SubFileName);
+        var subTerms = subNames.toLowerCase()
+                                 .split(/[^a-z0-9]+/gi)
+                                 .filter((tag) => { return tag.length > 1 }); ;
+        
+        if(subTerms.length === 0)  return 0;
+
+        var fileTagsDic = {};
+        _.each(fileTags, (term) => {
+            fileTagsDic[term] = false;
+        });
+
+        var maches = 0;
+        _.each(subTerms, (subTerm) => {
+            if (fileTagsDic[subTerm] === false) { // is term in filename, only once
+                fileTagsDic[subTerm] = true;
+                maches++;
+            }
+        });
+        return parseInt((maches / fileTags.length) * maxScore); 
+    };
 
     return new Promise(function(resolve, reject) {
         var subtitles = {};
@@ -120,10 +153,8 @@ LibSearch.prototype.optimizeSubs = function(response, input) {
 
             // episode check
             if (input.season && input.episode) {
-                if (sub.SeriesSeason !== parseInt(input.season).toString()) {
-                    return;
-                }
-                if (sub.SeriesEpisode !== parseInt(input.episode).toString()) {
+                if (sub.SeriesSeason !== parseInt(input.season).toString()
+                 || sub.SeriesEpisode !== parseInt(input.episode).toString()) {
                     return;
                 }
             }
@@ -142,6 +173,9 @@ LibSearch.prototype.optimizeSubs = function(response, input) {
             }
             if (sub.MatchedBy === 'tag') {
                 tmp.score += 7;
+            } 
+            else {
+                tmp.score += matchTags(sub, 7) ;
             }
             if (sub.MatchedBy === 'imdbid') {
                 tmp.score += 5;

--- a/lib/search.js
+++ b/lib/search.js
@@ -83,38 +83,61 @@ LibSearch.prototype.optimizeQueryTerms = function(input) {
 
 LibSearch.prototype.optimizeSubs = function(response, input) {
     // based on OpenSRTJS, under MIT - Copyright (c) 2014 Eóin Martin
-    var fileTags;
-    var matchTags = function (sub, maxScore) {
-        if(!input.filename) return 0;
-
-        if (!fileTags) {
-            fileTags = input.filename.toLowerCase()
-                                     .split(/[^a-z0-9]+/gi)
-                                     .filter((tag) => { return tag.length > 1 }); 
+    var normalize = (function () {
+        var from = "ÃÀÁÄÂÈÉËÊÌÍÏÎÒÓÖÔÙÚÜÛãàáäâèéëêìíïîòóöôùúüûÑñÇç", 
+            to =   "AAAAAEEEEIIIIOOOOUUUUaaaaaeeeeiiiioooouuuunncc",
+            mapping = {};
+        
+        for (var i = 0, j = from.length; i < j; i++)
+            mapping[ from.charAt(i) ] = to.charAt(i);
+        
+        return function (str) {
+            var ret = [];
+            for (var i = 0, j = str.length; i < j; i++) {
+                var c = str.charAt(i);
+                if (mapping.hasOwnProperty(str.charAt(i)))
+                    ret.push(mapping[ c ]);
+                else
+                    ret.push(c);
+            }
+            return ret.join('');
         }
-
+     
+    })();
+    
+    var fileTags;
+    var fileTagsDic = {};
+    var matchTags = function (sub, maxScore) {
+        if (!input.filename) return 0;
+        
+        if (!fileTags) {
+            fileTags = normalize(input.filename)
+                .toLowerCase()
+                .match(/[a-z0-9]{2,}/gi);
+        }
+        
         if (fileTags.length === 0) return 0;
         
-        var subNames = (sub.MovieReleaseName + ' ' + sub.SubFileName);
-        var subTerms = subNames.toLowerCase()
-                                 .split(/[^a-z0-9]+/gi)
-                                 .filter((tag) => { return tag.length > 1 }); ;
+        var subNames = normalize(sub.MovieReleaseName + '_' + sub.SubFileName);
+        var subTags = subNames
+            .toLowerCase()
+            .match(/[a-z0-9]{2,}/gi);
         
-        if(subTerms.length === 0)  return 0;
-
-        var fileTagsDic = {};
-        _.each(fileTags, (term) => {
-            fileTagsDic[term] = false;
+        
+        if (subTags.length === 0) return 0;
+        
+        _.each(fileTags, function (tag) {
+            fileTagsDic[tag] = false;
         });
-
-        var maches = 0;
-        _.each(subTerms, (subTerm) => {
-            if (fileTagsDic[subTerm] === false) { // is term in filename, only once
-                fileTagsDic[subTerm] = true;
-                maches++;
+        
+        var matches = 0;
+        _.each(subTags, function (subTag) {
+            if (fileTagsDic[subTag] === false) { // is term in filename, only once
+                fileTagsDic[subTag] = true;
+                matches++;
             }
         });
-        return parseInt((maches / fileTags.length) * maxScore); 
+        return parseInt((matches / fileTags.length) * maxScore);
     };
 
     return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Hello, I'm working on the repository popcorn time, trying to improve the subtitles.
When searching for TV Shows subtitles the program is currently uses the following object:
`{
    episode: "2",
    season: "2",
    filename: "Mr.Robot.S02E02.720p.HDTV.x264-AVS[rarbg]",
    imdbid: "tt0437745"
}`
But when calculating the score it never gives "MatchBy" Tags, it just chooses based on IMDB information, and ignores the file name.

This results on choosing:
- Mr.Robot.S02E02.1080p.WEBRip.AAC2.0.H.264-KNiTTiNG.str

above:
- Mr.Robot.S02E02.720p.HDTV.x264-AVS.str

because the user is not anonymous or totaly random

To solve this, I propose, when the server do not MatchBy Tag,
1. split the file name in tags.
2. split the Subtitle RelaseName and filename in tags.
3. look for file tags on the Subtitle tags.
4. finally ((matches / fileTags.length) \* maxscore).

Which returns a number of 0-7 (maxscore) according to how many tags found in subtitle
