### PR TITLE
Prevent asynchronous function without callback warning in Node 7

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -83,9 +83,13 @@ LibHash.prototype.computeHash = function(path) {
                         if (er1 || er2) {
                             return reject(er1 || er2);
                         }
-                        checksumReady(self.checksumBuffer(buf1, 16));
-                        checksumReady(self.checksumBuffer(buf2, 16));
-                        fs.close(fd);
+                        fs.close(fd, function(err) {
+                            if (err) {
+                                return reject(err);
+                            }
+                            checksumReady(self.checksumBuffer(buf1, 16));
+                            checksumReady(self.checksumBuffer(buf2, 16));
+                        });
                     });
                 });
             });

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -80,12 +80,9 @@ LibHash.prototype.computeHash = function(path) {
 
                 fs.read(fd, buf_start, 0, chunk_size * 2, 0, function(er1, bytesRead, buf1) {
                     fs.read(fd, buf_end, 0, chunk_size * 2, file_size - chunk_size, function(er2, bytesRead, buf2) {
-                        if (er1 || er2) {
-                            return reject(er1 || er2);
-                        }
-                        fs.close(fd, function(err) {
-                            if (err) {
-                                return reject(err);
+                        fs.close(fd, function(er3) {
+                            if (er1 || er2 || er3) {
+                                return reject(er1 || er2 || er3);
                             }
                             checksumReady(self.checksumBuffer(buf1, 16));
                             checksumReady(self.checksumBuffer(buf2, 16));


### PR DESCRIPTION
(node:10132) DeprecationWarning: Calling an asynchronous function without callback is deprecated.

https://nodejs.org/en/blog/release/v7.0.0/
A process warning is emitted if a callback is not passed to async file system methods #7897.

