### PR TITLE
fixed identify function

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,8 +148,8 @@ module.exports = class OpenSubtitles {
 
     /**
      * Movie identification service, get imdb information, send moviehashes
-     * @param {Object}          
-     * 
+     * @param {Object}
+     *
      * @param {String}          path - Mandatory, absolute path to a video file
      * @param {String}          imdb - Optionnal, matching imdb id
      * @param {Boolean}         extend - Optionnal, fetches metadata from OpenSubtitles
@@ -159,7 +159,7 @@ module.exports = class OpenSubtitles {
         if (!query.path) query = {path: query}
 
         return this.login()
-            .then(() => this.extractInfo(query.path))
+            .then(() => this.hash(query.path))
             .then(info => {
                 query.moviehash = info.moviehash
                 query.moviebytesize = info.moviebytesize

--- a/lib/identify.js
+++ b/lib/identify.js
@@ -3,7 +3,7 @@ const libhash = require('./hash.js')
 const path = require('path')
 const fs = require('fs')
 
-module.exports = class LibID {
+module.exports = new class LibID {
     readNFO(file) {
         let p = path.parse(file)
         let nfo = path.join(p.dir, p.name + '.nfo')
@@ -18,7 +18,7 @@ module.exports = class LibID {
             }
         }
 
-        detectedId = fs.readFileSync(nfo).toString().match(/tt\d+/i)
+        if (fs.existsSync(nfo)) detectedId = fs.readFileSync(nfo).toString().match(/tt\d+/i)
         return detectedId ? detectedId[0] : undefined
     }
 


### PR DESCRIPTION
fixed hash method name (was calling `extractInfo`), instanciate `LibID` class for module export & check for .nfo file before trying to reading it in `LibID.readNFO`