### PR TITLE
Sorting fix + additional field

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -145,6 +145,7 @@ module.exports = new class LibSearch {
                 encoding: sub.SubEncoding,
                 id: sub.IDSubtitleFile,
                 filename: sub.SubFileName,
+                addedon: sub.SubAddDate,
                 score: 0
             }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -140,7 +140,7 @@ module.exports = new class LibSearch {
             const tmp = {
                 url: input.gzip ? sub.SubDownloadLink : sub.SubDownloadLink.replace('.gz', ''),
                 langcode: sub.ISO639,
-                downloads: sub.SubDownloadsCnt,
+                downloads: parseInt(sub.SubDownloadsCnt),
                 lang: sub.LanguageName,
                 encoding: sub.SubEncoding,
                 id: sub.IDSubtitleFile,


### PR DESCRIPTION
Hi,

I noticed that sub-sorting per number of downloads was sorting as a string, not number, so I added a fix for that.
Also, I would find it useful if the search result included the date when the subtitle was uploaded. I also added a commit for this.