### PR TITLE
exit early for empty response

### DIFF
--- a/lib/identify.js
+++ b/lib/identify.js
@@ -64,7 +64,7 @@ module.exports = new class LibID {
     }
 
     extend(data, response) {
-        if (response.data !== String() && response.status.match(/200/)) {
+        if (response.data !== String() && response.status.match(/200/) && response.data.length) {
             if (response.data.kind.match(/episode/i)) {
                 data.type = 'episode'
             } else if (response.data.kind.match(/movie/i)) {


### PR DESCRIPTION
Fixes:

```
await osAPI.identify({
  moviehash: 'a04cfbeafc4af7eb',
  moviebytesize: 884419440,
  extend: true
});
```

```
TypeError: Cannot read property 'match' of undefined
    at LibID.extend (/Users/kyle-dev/umsapi/node_modules/opensubtitles-api/lib/identify.js:71:36)
    at /Users/kyle-dev/umsapi/node_modules/opensubtitles-api/index.js:209:42
```

In the above case, response.data is an empty array throwing the error