### PR TITLE
fixup identify.js bugfix & add test

### DIFF
--- a/lib/identify.js
+++ b/lib/identify.js
@@ -64,10 +64,10 @@ module.exports = new class LibID {
     }
 
     extend(data, response) {
-        if (response.data !== String() && response.status.match(/200/) && response.data.length) {
-            if (response.data.kind.match(/episode/i)) {
+        if (response.data !== String() && response.status.match(/200/)) {
+            if (response.data.kind && response.data.kind.match(/episode/i)) {
                 data.type = 'episode'
-            } else if (response.data.kind.match(/movie/i)) {
+            } else if (response.data.kind && response.data.kind.match(/movie/i)) {
                 data.type = 'movie'
             } else {
                 delete data.metadata

--- a/tests.js
+++ b/tests.js
@@ -1,4 +1,5 @@
 const OS = require('./index.js');
+const assert = require('assert');
 const UA = 'TemporaryUserAgent';
 const imdb = '0898266', show = 'The Big Bang Theory', s = '01', ep = '01';
 
@@ -32,9 +33,20 @@ os.api.ServerInfo().then(() => {
         limit: 'all'
     });
 }).then(() => {
+    test = 'identify';
+    console.time(test);
+    return os.identify({
+        moviehash: '8e245d9679d31e12',
+        moviebytesize: 1234,
+        extend: true,
+    });
+}).then((res) => {
     console.timeEnd(test);
+    assert.equal(res.metadata.title, 'The Simpsons Movie');
     console.log('Passed test.');
+    process.exit(0);
 }).catch((err) => {
     console.log('Test failed');
     console.log(err);
+    process.exit(1);
 });


### PR DESCRIPTION
Hi there again,

Unfortunately I realised my last bugfix for identify.js probably broke some things unintentionally.

I think this should be a better fix for the issue:

```
TypeError: Cannot read property 'match' of undefined
    at LibID.extend (/Users/kyle-dev/umsapi/node_modules/opensubtitles-api/lib/identify.js:68:36)
```

I've added a small test for the function